### PR TITLE
Fixes a crash when there are pending transactions

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,7 @@
 (defproject bankaccount "0.1.0-SNAPSHOT"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
+  :main bankaccount.core
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]])

--- a/src/bankaccount/core.clj
+++ b/src/bankaccount/core.clj
@@ -39,7 +39,7 @@
      (simulate-delay)
      (alter to-account + amount))
     (catch IllegalStateException _
-      (swap! pending-transactions conj @pending-transactions [amount from-account to-account]))))
+      (swap! pending-transactions conj [amount from-account to-account]))))
 
 (defn random-transactions-of-account
   [account]
@@ -62,11 +62,9 @@
 (defn do-pending-transactions
   []
   (while (not (empty? @pending-transactions))
-    (let [current-transaction (atom 0)]
-      (swap! #(do (reset! current-transaction (first %))
-                  (rest %))
-             @pending-transactions)
-      (apply transfert-money current-transaction))))
+    (let [[current-transaction & the-rest] @pending-transactions]
+      (apply transfert-money current-transaction)
+      (reset! pending-transactions the-rest))))
 
 (defn compare-account-balances
   [old new]


### PR DESCRIPTION
When pending transactions were detected, the thing crashed.

My clojure is very rusty so I might have gotten this wrong, but this is
what I gather from it :
- Adding to the pending-tx atom was creating duplicates, because it was
  running with (swap! pending-tx conj @pending-tx new-tx), which conj's
  pending-tx with itself.
- The do-pending-tx method was not derefencing the atom when applying
  it, which cause the error "java.lang.ClassCastException:
  bankaccount.core$do_pending_transactions$fn__65 cannot be cast to
  clojure.lang.Atom".
